### PR TITLE
Feature/complete kotlin coroutines benchmark system

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Este projeto demonstra a efetividade das **Kotlin Coroutines** comparando difere
 
 ## 📊 Principais Resultados
 
-Baseado nos benchmarks executados, **Spring WebFlux com Coroutines** apresentou a melhor performance:
-- **96.5% mais rápido** que a abordagem mais lenta
-- **27.02 requisições/segundo** em testes de carga concorrente
-- **88ms** de tempo médio de resposta
+Baseado nos benchmarks executados com **20 requisições** (padronização para comparação), **Spring WebFlux com Coroutines** apresentou a melhor performance:
+- **96.6% mais rápido** que a abordagem mais lenta
+- **193.79 requisições/segundo** em testes de carga concorrente (100 requisições simultâneas)
+- **86ms** de tempo médio de resposta
 
 ## 🎯 Objetivo
 
@@ -145,13 +145,15 @@ Os relatórios são salvos em arquivos como `performance-report-YYYYMMDD-HHMMSS.
 - Recomendações técnicas
 - Cenários de uso para cada abordagem
 
-## 🏆 Resultados Típicos
+## 🏆 Resultados Oficiais (20 Requisições)
 
-| Abordagem                | Tempo Médio | Req/s | Uso Recomendado            |
-| ------------------------ | ----------- | ----- | -------------------------- |
-| **WebFlux + Coroutines** | ~88ms       | 27.02 | 🎯 **Melhor escolha geral** |
-| MVC + Coroutines         | ~142ms      | 18.75 | Migração gradual           |
-| MVC Blocking             | ~1068ms     | 5.17  | Baixa concorrência         |
+| Abordagem                | Tempo Médio | Req/s (Carga) | Uso Recomendado            |
+| ------------------------ | ----------- | ------------- | -------------------------- |
+| **WebFlux + Coroutines** | **86ms**    | **193.79**    | 🎯 **Melhor escolha geral** |
+| MVC + Coroutines         | 143ms       | 174.21        | Migração gradual           |
+| MVC Blocking             | 1060ms      | 104.38        | Baixa concorrência         |
+
+*Testes executados com 20 requisições sequenciais e 100 requisições concorrentes para carga*
 
 ## 🎯 Cenários de Uso Recomendados
 
@@ -199,7 +201,7 @@ Este projeto demonstra:
 
 - [`TECHNICAL_DETAILS.md`](./TECHNICAL_DETAILS.md) - Detalhes técnicos e arquitetura
 - [`EXAMPLES.md`](./EXAMPLES.md) - Exemplos práticos e cenários de teste
-- [`performance-report-*.txt`](./performance-report-20250815-184814.txt) - Relatórios de benchmark
+- [`performance-report-*.txt`](./performance-report-20250816-225541.txt) - Relatórios de benchmark oficiais
 - [`Makefile`](./Makefile) - Automação de tarefas e comandos
 
 ## 🤝 Contribuição
@@ -217,4 +219,6 @@ Este projeto é destinado para fins educacionais e de demonstração.
 
 ---
 
-**🎯 Conclusão**: Spring WebFlux com Kotlin Coroutines oferece a melhor combinação de performance, escalabilidade e experiência de desenvolvimento para aplicações modernas. 
+**🎯 Conclusão**: Spring WebFlux com Kotlin Coroutines oferece a melhor combinação de performance, escalabilidade e experiência de desenvolvimento para aplicações modernas.
+
+**📊 Comparação**: Este projeto utiliza **20 requisições** como padrão para permitir comparação direta com projetos similares como `java-virtual-threads-sample`. 

--- a/performance-report-20250816-225541.txt
+++ b/performance-report-20250816-225541.txt
@@ -1,0 +1,181 @@
+RELATÓRIO DE PERFORMANCE - KOTLIN COROUTINES
+=============================================================
+Data/Hora: Sat Aug 16 22:55:41 -03 2025
+Configuração:
+- Warmup requests: 5
+- Test requests: 20
+- Concurrent requests: 100
+
+----------------------------------------
+TESTE: Spring MVC Blocking
+Endpoint: http://localhost:8080/api/mvc/persons/blocking?count=10
+Descrição: Spring MVC tradicional com blocking I/O
+Data/Hora: Sat Aug 16 22:56:12 -03 2025
+
+RESULTADOS:
+- Requisições válidas: 20/20
+- Tempo médio: 1060ms
+- Tempo mínimo: 1045ms
+- Tempo máximo: 1073ms
+
+----------------------------------------
+TESTE: Spring MVC com Coroutines
+Endpoint: http://localhost:8080/api/mvc/persons/async?count=10
+Descrição: Spring MVC com Kotlin Coroutines
+Data/Hora: Sat Aug 16 22:56:17 -03 2025
+
+RESULTADOS:
+- Requisições válidas: 20/20
+- Tempo médio: 143ms
+- Tempo mínimo: 131ms
+- Tempo máximo: 158ms
+
+----------------------------------------
+TESTE: WebFlux List
+Endpoint: http://localhost:8080/api/webflux/persons/list?count=10
+Descrição: Spring WebFlux list com Coroutines
+Data/Hora: Sat Aug 16 22:56:19 -03 2025
+
+RESULTADOS:
+- Requisições válidas: 20/20
+- Tempo médio: 86ms
+- Tempo mínimo: 80ms
+- Tempo máximo: 91ms
+
+----------------------------------------
+TESTE: WebFlux Parallel
+Endpoint: http://localhost:8080/api/webflux/persons/parallel?batches=2&countPerBatch=5
+Descrição: Spring WebFlux parallel com Kotlin Coroutines
+Data/Hora: Sat Aug 16 22:57:24 -03 2025
+
+RESULTADOS:
+- Requisições válidas: 20/20
+- Tempo médio: 2555ms
+- Tempo mínimo: 2544ms
+- Tempo máximo: 2562ms
+
+----------------------------------------
+TESTE: Benchmark Coroutines vs Blocking
+Endpoint: http://localhost:8080/api/benchmark/coroutines-vs-blocking?count=20
+Descrição: Benchmark direto Coroutines vs Blocking
+Data/Hora: Sat Aug 16 22:58:19 -03 2025
+
+RESULTADOS:
+- Requisições válidas: 20/20
+- Tempo médio: 2172ms
+- Tempo mínimo: 2160ms
+- Tempo máximo: 2200ms
+
+----------------------------------------
+TESTE: Benchmark WebFlux vs MVC
+Endpoint: http://localhost:8080/api/benchmark/webflux-vs-mvc?count=20
+Descrição: Benchmark WebFlux vs MVC com Coroutines
+Data/Hora: Sat Aug 16 22:58:24 -03 2025
+
+RESULTADOS:
+- Requisições válidas: 20/20
+- Tempo médio: 198ms
+- Tempo mínimo: 188ms
+- Tempo máximo: 207ms
+
+TESTE DE CARGA CONCORRENTE: MVC Blocking Concorrente
+- Requisições simultâneas: 100
+- Tempo total: 958ms
+- Requisições por segundo: 104.38
+
+TESTE DE CARGA CONCORRENTE: MVC Coroutines Concorrente
+- Requisições simultâneas: 100
+- Tempo total: 574ms
+- Requisições por segundo: 174.21
+
+TESTE DE CARGA CONCORRENTE: WebFlux List Concorrente
+- Requisições simultâneas: 100
+- Tempo total: 516ms
+- Requisições por segundo: 193.79
+
+TESTE DE CARGA CONCORRENTE: WebFlux Parallel Concorrente
+- Requisições simultâneas: 100
+- Tempo total: 1940ms
+- Requisições por segundo: 51.54
+
+
+=============================================================
+ANÁLISE COMPARATIVA DETALHADA
+=============================================================
+
+🚀 ANÁLISE DE PERFORMANCE (Tempo de Resposta)
+-------------------------------------------------------------
+• benchmark_coroutines: 2172ms médio (min: 2160ms, max: 2200ms)
+• benchmark_webflux_mvc: 198ms médio (min: 188ms, max: 207ms)
+• mvc_blocking: 1060ms médio (min: 1045ms, max: 1073ms)
+• mvc_coroutines: 143ms médio (min: 131ms, max: 158ms)
+• webflux_list: 86ms médio (min: 80ms, max: 91ms)
+• webflux_parallel: 2555ms médio (min: 2544ms, max: 2562ms)
+
+🏆 VENCEDOR EM PERFORMANCE: webflux_list (86ms)
+🐌 MAIS LENTO: webflux_parallel (2555ms)
+📈 MELHORIA: 96.6% mais rápido que a abordagem mais lenta
+
+⚡ ANÁLISE DE CARGA CONCORRENTE
+-------------------------------------------------------------
+• mvc_blocking: 958ms total (104.38 req/s)
+• mvc_coroutines: 574ms total (174.21 req/s)
+• webflux_list: 516ms total (193.79 req/s)
+• webflux_parallel: 1940ms total (51.54 req/s)
+
+🏆 MELHOR EM CARGA: webflux_list (516ms)
+🐌 PIOR EM CARGA: webflux_parallel (1940ms)
+
+🎯 ANÁLISE TÉCNICA E RECOMENDAÇÕES
+=============================================================
+
+📋 CARACTERÍSTICAS DE CADA ABORDAGEM:
+
+1. SPRING MVC BLOCKING:
+   ✅ Simplicidade de implementação
+   ✅ Familiar para a maioria dos desenvolvedores
+   ❌ Bloqueia threads durante I/O
+   ❌ Baixa escalabilidade com alta concorrência
+   💡 USAR QUANDO: Aplicações com baixa concorrência
+
+2. SPRING MVC COM COROUTINES:
+   ✅ Sintaxe simples e familiar
+   ✅ Não bloqueia threads durante suspensão
+   ✅ Boa escalabilidade
+   ⚠️  Requer runBlocking para integração com MVC
+   💡 USAR QUANDO: Migração gradual para programação assíncrona
+
+3. SPRING WEBFLUX:
+   ✅ Totalmente não-bloqueante
+   ✅ Excelente para alta concorrência
+   ✅ Suporte nativo para streams
+   ❌ Curva de aprendizado mais íngreme
+   💡 USAR QUANDO: Alta concorrência, APIs reativas
+
+4. WEBFLUX COM COROUTINES:
+   ✅ Combina benefícios do WebFlux com sintaxe simples
+   ✅ Melhor experiência de desenvolvimento
+   ✅ Performance excelente
+   🎯 RECOMENDAÇÃO PRINCIPAL para novos projetos
+
+🏆 RECOMENDAÇÃO FINAL
+=============================================================
+🎯 SPRING WEBFLUX COM COROUTINES é a MELHOR ESCOLHA!
+
+JUSTIFICATIVA:
+• Melhor performance nos testes (86ms)
+• Excelente escalabilidade
+• Sintaxe clara com Coroutines
+• Totalmente não-bloqueante
+
+📊 CENÁRIOS DE USO RECOMENDADOS:
+• 🚀 APIs de alta performance: WebFlux + Coroutines
+• 🔄 Migração de projetos legados: MVC + Coroutines
+• 🎯 Novos microserviços: WebFlux + Coroutines
+• 📱 Aplicações com muitas chamadas externas: Coroutines
+• 🏢 Sistemas corporativos tradicionais: MVC + Coroutines
+
+=============================================================
+📝 RELATÓRIO GERADO EM: Sat Aug 16 22:58:31 -03 2025
+🔧 FERRAMENTA: Kotlin Coroutines Performance Benchmark
+=============================================================


### PR DESCRIPTION
This pull request updates the official benchmark results and documentation for the Kotlin Coroutines performance comparison project. The main focus is on standardizing the benchmark methodology (using 20 sequential and 100 concurrent requests), updating performance numbers, and providing a new, detailed benchmark report. These changes ensure more accurate and comparable results with similar projects.

**Documentation and Results Update:**

* Standardized the benchmarking methodology to use 20 sequential requests and 100 concurrent requests for all performance tests, and clarified this in both the summary and comparison sections of the `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L148-R156) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R223-R224)
* Updated the performance results table and summary in `README.md` with new, significantly higher throughput and slightly improved latency numbers, reflecting the standardized tests. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L148-R156)

**Benchmark Report:**

* Added a new, detailed official benchmark report file `performance-report-20250816-225541.txt`, including breakdowns for each tested approach, concurrent load test results, and technical recommendations.
* Updated the reference in `README.md` to point to the new official benchmark report file.